### PR TITLE
Disabling auto_describe in CollectorRegistry

### DIFF
--- a/prometheus_exporter.py
+++ b/prometheus_exporter.py
@@ -9,8 +9,8 @@ from airflow.models import DagStat, TaskInstance, DagModel, DagRun
 from airflow.utils.state import State
 
 # Importing base classes that we need to derive
-from prometheus_client import generate_latest, REGISTRY
-from prometheus_client.core import GaugeMetricFamily
+from prometheus_client import generate_latest
+from prometheus_client.core import GaugeMetricFamily, CollectorRegistry
 
 from contextlib import contextmanager
 
@@ -116,8 +116,8 @@ class MetricsCollector(object):
         yield dag_duration
 
 
+REGISTRY = CollectorRegistry(auto_describe=False)
 REGISTRY.register(MetricsCollector())
-
 
 class Metrics(BaseView):
     @expose('/')


### PR DESCRIPTION
The default setting in the prometheus client is to initialize
CollectorRegistry with auto_describe=True (See https://github.com/prometheus/client_python/blob/v0.4.2/prometheus_client/core.py#L195)

This setting causes the prometheus client to call the collect method to discover metric names,
which is also executed on the workers during plugin loading and causes the relatively
heavy queries to run on every sync/reload of the folders.